### PR TITLE
Fix for old acada data and new ctapipe, require 0.24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,11 +46,11 @@ jobs:
           - python-version: "3.12"
             os: ubuntu-latest
             extra-args: ['codecov']
-            ctapipe: "0.25.0"
+            ctapipe: "0.25.1"
 
           - python-version: "3.13"
             os: ubuntu-latest
-            ctapipe: "0.25.0"
+            ctapipe: "0.26.0"
 
     runs-on: ${{ matrix.os }}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ requires-python = ">=3.10"
 dependencies = [
     "numpy",
     "protozfits ~=2.7",
-    "ctapipe >=0.23.0,<0.26.0a0",
+    "ctapipe >=0.24.0,<0.26.0a0",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ requires-python = ">=3.10"
 dependencies = [
     "numpy",
     "protozfits ~=2.7",
-    "ctapipe >=0.24.0,<0.26.0a0",
+    "ctapipe >=0.24.0,<0.27.0a0",
 ]
 
 [project.optional-dependencies]

--- a/src/ctapipe_io_zfits/dl0.py
+++ b/src/ctapipe_io_zfits/dl0.py
@@ -97,7 +97,7 @@ def _fill_dl0_container(
     if n_pixels_stored == camera_config.num_pixels and np.all(
         PixelStatus.get_dvr_status(pixel_status) == 0
     ):
-        pixel_status = pixel_status | PixelStatus.DVR_STORED_AS_SIGNAL
+        pixel_status = pixel_status | PixelStatus.DVR_1
 
     pixel_stored = PixelStatus.get_dvr_status(pixel_status) != 0
     n_pixels_nominal = camera_geometry.n_pixels


### PR DESCRIPTION
One edge condition was not tested and missed an API change in ctapipe