### PR TITLE
remove condition in CI which prevented CI to be executed PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,10 +35,6 @@ jobs:
 
   tests:
     continue-on-error: ${{ matrix.ctapipe-ref == 'main' }}
-    if: >
-      github.event_name != 'schedule' ||
-      (matrix.python-version == '3.13' &&
-      matrix.ctapipe-ref == 'main')
     strategy:
       matrix:
         include:


### PR DESCRIPTION
I saw on #22 that CI is not running on PRs anymore after `schedule` condition was introduced in the CI tests.