### PR TITLE
Drop support for ctapipe < 0.28

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,34 +38,22 @@ jobs:
     strategy:
       matrix:
         include:
-          - python-version: "3.10"
-            os: ubuntu-latest
-            ctapipe: "0.23.1"
-
-          - python-version: "3.11"
-            os: ubuntu-latest
-            ctapipe: "0.24.0"
-
-          - python-version: "3.12"
-            os: ubuntu-latest
-            extra-args: ['codecov']
-            ctapipe: "0.25.1"
-
-          - python-version: "3.13"
-            os: ubuntu-latest
-            ctapipe: "0.26.0"
-
-          - python-version: "3.13"
-            os: ubuntu-latest
-            ctapipe: "0.27.1"
-
           - python-version: "3.13"
             os: ubuntu-latest
             ctapipe: "0.28.0"
 
-          - python-version: "3.13"
+          - python-version: "3.12"
             os: ubuntu-latest
             ctapipe: "0.29.0"
+
+          - python-version: "3.12"
+            os: ubuntu-latest
+            extra-args: ['codecov']
+            ctapipe: "0.30.0"
+
+          - python-version: "3.14"
+            os: ubuntu-latest
+            ctapipe: "0.30.0"
 
           - python-version: "3.13"
             os: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,14 +46,14 @@ jobs:
             os: ubuntu-latest
             ctapipe: "0.29.0"
 
-          - python-version: "3.12"
-            os: ubuntu-latest
-            extra-args: ['codecov']
-            ctapipe: "0.30.0"
-
           - python-version: "3.14"
             os: ubuntu-latest
             ctapipe: "0.30.0"
+
+          - python-version: "3.12"
+            os: ubuntu-latest
+            extra-args: ['codecov']
+            ctapipe: "0.31.0"
 
           - python-version: "3.13"
             os: ubuntu-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ requires-python = ">=3.10"
 dependencies = [
     "numpy",
     "protozfits >=2.7.3,<3.0.0",
-    "ctapipe >=0.24.0",
+    "ctapipe >=0.28.0",
 ]
 
 [project.optional-dependencies]

--- a/src/ctapipe_io_zfits/dl0.py
+++ b/src/ctapipe_io_zfits/dl0.py
@@ -3,10 +3,10 @@
 import logging
 from contextlib import ExitStack
 
-import ctapipe
 import numpy as np
 from ctapipe.containers import (
     ArrayEventContainer,
+    CameraCalibrationContainer,
     DL0CameraContainer,
     EventIndexContainer,
     EventType,
@@ -20,7 +20,6 @@ from ctapipe.core.traits import Bool, Integer
 from ctapipe.instrument import SubarrayDescription
 from ctapipe.io import DataLevel, EventSource
 from ctapipe.io.simteleventsource import GainChannel
-from packaging.version import Version
 from protozfits import File
 
 from .instrument import build_subarray_description, get_array_elements_by_id
@@ -35,11 +34,6 @@ __all__ = [
 log = logging.getLogger(__name__)
 
 ARRAY_ELEMENTS = get_array_elements_by_id()
-
-
-CTAPIPE_GE_0_27 = Version(ctapipe.__version__) >= Version("0.27.0a0")
-if CTAPIPE_GE_0_27:
-    from ctapipe.containers import CameraCalibrationContainer
 
 
 def _is_compatible(input_url, extname, allowed_protos):
@@ -343,10 +337,8 @@ class ProtozfitsDL0EventSource(EventSource):
                 )
                 array_event.dl0.tel[tel_id] = dl0_tel
 
-                # fill minimum calibration info to make tool work.
-                if CTAPIPE_GE_0_27:
-                    n_channels = camera.readout.n_channels
-                    _fill_calibration_container(array_event, tel_id, n_channels)
+                n_channels = camera.readout.n_channels
+                _fill_calibration_container(array_event, tel_id, n_channels)
 
             yield array_event
 
@@ -464,9 +456,7 @@ class ProtozfitsDL0TelescopeEventSource(EventSource):
             ignore_samples_start=self.ignore_samples_start,
             ignore_samples_end=self.ignore_samples_end,
         )
-        # fill minimum calibration info to make tool work.
-        if CTAPIPE_GE_0_27:
-            _fill_calibration_container(array_event, tel_id, camera.readout.n_channels)
+        _fill_calibration_container(array_event, tel_id, camera.readout.n_channels)
         return array_event
 
     def _generator(self):


### PR DESCRIPTION
CI failed because of setuptools removing `pkg_resources` and older ctapipe versions requiring older pytables version that now fails to install without pinning setuptools.

I think there is no reason to support these older ctapipe versions here anymore, so simply dropping.